### PR TITLE
Bump transformers upper bound

### DIFF
--- a/monad-journal.cabal
+++ b/monad-journal.cabal
@@ -42,7 +42,7 @@ library
 
   build-depends:           base              >= 4.5   && < 5.0
                          , mtl               >= 2.1   && < 2.3
-                         , transformers      >= 0.3   && < 0.5
+                         , transformers      >= 0.3   && < 0.6
                          , either            >= 4.1   && < 4.5
                          , monad-control     >= 0.3   && < 1.1
                          , transformers-base >= 0.4   && < 0.5


### PR DESCRIPTION
I tested that it builds.

This is necessary for GHC 8 so it would be great if you could make a release for it rather soon as it’s blocking other projects from supporting GHC 8.